### PR TITLE
Iteration3 harness

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -216,12 +216,14 @@ class SalesAnalyst
     end
   end
 
-  def invoice_total(invoice_id)
-    total = @engine.invoice_items.find_all_by_invoice_id(invoice_id)
-
-    total.sum do |invoice_item|
-      require "pry"; binding.pry
-      invoice_item.quantity * invoice_item.unit_price
+  def invoice_total(invoice_id) #invoice_id(2)
+    invoice_items = @engine.invoice_items.find_all_by_invoice_id(invoice_id)
+    # item_id(1) * qty(10) @ unit_price(0.1e2)
+    # item_id(2) * qty(10) @ unit_price(0.12e2)
+    # item_id(4) * qty(1) @ unit_price(0.2e2)
+    total = invoice_items.sum do |invoice_item|
+      invoice_item.unit_price * invoice_item.quantity
     end
+    # => 0.24e3
   end
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -207,4 +207,13 @@ class SalesAnalyst
     # tested and works for 66.6666 to round to 66.67
     ((invoices.length / @engine.invoices.all.length.to_f) * 100).round(2)
   end
+
+  def invoice_paid_in_full?(invoice_id)
+    transaction = @engine.transactions.find_all_by_invoice_id(invoice_id)
+
+    transaction.any? do |transaction|
+      transaction.result == :success
+    end
+  end
+
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -216,4 +216,12 @@ class SalesAnalyst
     end
   end
 
+  def invoice_total(invoice_id)
+    total = @engine.invoice_items.find_all_by_invoice_id(invoice_id)
+
+    total.sum do |invoice_item|
+      require "pry"; binding.pry
+      invoice_item.quantity * invoice_item.unit_price
+    end
+  end
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe SalesEngine do
     @se = SalesEngine.from_csv({
                                   :items => './spec/fixture_files/item_fixture.csv',
                                   :merchants => './spec/fixture_files/merchant_fixture.csv',
-                                  :invoices => './spec/fixture_files/invoice_fixture.csv'
+                                  :invoices => './spec/fixture_files/invoice_fixture.csv',
+                                  :invoice_items => './spec/fixture_files/invoice_item_fixture.csv',
+                                  :customers => './spec/fixture_files/customer_fixture.csv',
+                                  :transactions => './spec/fixture_files/transactions_fixture.csv'
                                })
 
     @sales_analyst = @se.analyst
@@ -154,5 +157,10 @@ RSpec.describe SalesEngine do
     expect(@sales_analyst.invoice_status(:pending)).to eq(60.0)
     expect(@sales_analyst.invoice_status(:shipped)).to eq(40.0)
     expect(@sales_analyst.invoice_status(:returned)).to eq(0)
+  end
+
+  it 'returns true if the invoice with corresponding id is paid in full' do
+    expect(@sales_analyst.invoice_paid_in_full?(1)). to eq(true)
+    expect(@sales_analyst.invoice_paid_in_full?(6)). to eq(false)
   end
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -165,6 +165,6 @@ RSpec.describe SalesEngine do
   end
 
   it 'returns the total amount of the invoice with corresponding id' do
-    expect(@sales_analyst.invoice_total(2).to eq(240.00)
+    expect(@sales_analyst.invoice_total(2)).to eq(240.00)
   end
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -163,4 +163,8 @@ RSpec.describe SalesEngine do
     expect(@sales_analyst.invoice_paid_in_full?(1)). to eq(true)
     expect(@sales_analyst.invoice_paid_in_full?(6)). to eq(false)
   end
+
+  it 'returns the total amount of the invoice with corresponding id' do
+    expect(@sales_analyst.invoice_total(2).to eq(240.00)
+  end
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -165,6 +165,6 @@ RSpec.describe SalesEngine do
   end
 
   it 'returns the total amount of the invoice with corresponding id' do
-    expect(@sales_analyst.invoice_total(2)).to eq(240.00)
+    expect(@sales_analyst.invoice_total(2)).to eq(BigDecimal(240))
   end
 end

--- a/spec/sales_engine_spec.rb
+++ b/spec/sales_engine_spec.rb
@@ -4,7 +4,7 @@ SimpleCov.start
 require_relative '../lib/sales_engine'
 require_relative '../lib/item_repository'
 require_relative '../lib/merchant_repository'
-require_relative '../lib/tranaction_repository'
+require_relative '../lib/transaction_repository'
 require_relative '../lib/sales_analyst'
 
 RSpec.describe SalesEngine do


### PR DESCRIPTION
What I did:
- Added iteration 3 business intelligence methods to sales_analyst
    - invoice_paid_in_full?
    - invoice_total

Roadblocks:
- Was unsure if we needed to link invoice_items to items since transactions do not have totals
- Thought invoice_total needed to be a float, but spec harness indicated BigDecimal

Tests:
- One rspec test for each method added
- Spec harness tested satisfactorily

Notes:
- Few rspec tests unsat due to format errors during last merge. Should correct itself with merge of iteration2.
- Comments remaining in code so you can verify information if necessary